### PR TITLE
feat: remove toast

### DIFF
--- a/src/components/notification-email-form.tsx
+++ b/src/components/notification-email-form.tsx
@@ -29,7 +29,6 @@ export const NotificationEmailForm = ({
 
     switch (result.type) {
       case "Success":
-        toast.success("Success!");
         return;
       case "ValidationError":
         error = result?.error?.message ?? error;


### PR DESCRIPTION
Removes the success toast after the email submission.

I am not sure if there is an easy way of testing this before merging it to development since the fractal redirects back to development deployment on vercel.

fixes #55 