### PR TITLE
Fix: Scroll to bottom bug

### DIFF
--- a/src/components/terms-modal.tsx
+++ b/src/components/terms-modal.tsx
@@ -26,7 +26,7 @@ export default function TermsModal() {
     const handleScroll = () => {
       if (termsContainer) {
         const { scrollTop, scrollHeight, clientHeight } = termsContainer;
-        if (scrollTop + clientHeight >= scrollHeight) {
+        if (scrollTop + clientHeight >= scrollHeight - 2) {
           setHasScrolledToBottom(true);
         }
       }


### PR DESCRIPTION
Add some tolerance to scroll check, on my device it was off by 0.5px for some reason and I could never accept terms and conditions.