### PR TITLE
feat: increase max cloud function duration

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "functions": {
+    "src/app/**/*": {
+      "maxDuration": 25
+    }
+  }
+}


### PR DESCRIPTION
**Description**
This PR increases max cloud function duration to fix the issue where the request times out intermittently when the function tries to load the merkle tree

**Tested**
Tested on a preview, looks ok now
This will be also merged to focus-day branch and we will check the logs after testing to see how many times we have huge load times and and then decide if this is good enough or if we need a proper solution

**Fixes**
https://github.com/mento-protocol/mento-general/issues/388