### PR TITLE
feat: use lowercase addresses in getAllocationForAddress

### DIFF
--- a/src/lib/merkle/merkle.ts
+++ b/src/lib/merkle/merkle.ts
@@ -69,7 +69,7 @@ export const getAllocationForAddress = (
   address: string,
 ): string | undefined => {
   // Get the checksummed address
-  const searchAddress = getAddress(address);
+  const searchAddress = getAddress(address).toLowerCase();
 
   // Get the allocation for the address
   const allocation = getAllocationList(getTree())[searchAddress];


### PR DESCRIPTION
## Description

getAllocationForAddress() uses check-sum address to search for the allocation of an address but the snapshot has the addresses in lower case. This causes eligible addresses to look like ineligible on the client.

This PR updates the function to search with the lower case address 

## Tested

Tested on testing branch preview

## Related Issue

Fixes #116 



