### PR TITLE
feat: extend FAQs when navigated

### DIFF
--- a/src/components/faq.tsx
+++ b/src/components/faq.tsx
@@ -5,6 +5,8 @@ import { motion } from "framer-motion";
 import { ChevronDown } from "./svgs";
 import Link from "next/link";
 import { links } from "@/lib/constants";
+import { useEffect, useState } from "react";
+import { useParams } from "next/navigation";
 
 export interface FAQ {
   id: string;
@@ -18,12 +20,23 @@ export default function FAQ() {
       <h2 className="font-fg text-center font-medium text-xl  md:text-[56px] tracking-[-0.02em] leading-none mb-3 dark:text-clean-white">
         Frequently asked questions
       </h2>
-      <AccordianMenu list={faqs} />
+      <AccordionMenu list={faqs} />
     </div>
   );
 }
 
-const AccordianMenu = ({ list }: { list: FAQ[] }) => {
+const AccordionMenu = ({ list }: { list: FAQ[] }) => {
+  const [openDisclosureId, setOpenDisclosureId] = useState<string | null>(null);
+  const params = useParams();
+
+  useEffect(() => {
+    const anchor = window.location.hash.replace("#", "");
+    setOpenDisclosureId(anchor);
+    document.getElementById(anchor)?.scrollIntoView({ behavior: "smooth" });
+  }, [params]);
+
+  const isDisclosureOpen = (id: string) => openDisclosureId === id;
+
   return (
     <div className="w-full flex flex-col mb-8 dark:bg-primary-dark">
       {list.map(({ question, answer, id }) => {
@@ -32,29 +45,40 @@ const AccordianMenu = ({ list }: { list: FAQ[] }) => {
             as="div"
             className="leading-[118%] bg-clean-white rounded-md border border-primary-dark dark:border-clean-white mt-[18px] sm:mt-8 md:mt-8"
             key={question}
+            defaultOpen={isDisclosureOpen(id)}
           >
-            {({ open }) => (
-              <>
-                <Disclosure.Button
-                  id={id}
-                  className={`${
-                    open ? "border-b" : ""
-                  }  p-[1rem] pl-8 sm:p-[1.875rem] md:p-[1.875rem] sm:text-base mt-2 font-medium text-left text-sm font-fg flex justify-between w-full`}
-                >
-                  {question}
+            <>
+              <Disclosure.Button
+                id={id}
+                className={`${
+                  isDisclosureOpen(id) ? "border-b" : ""
+                }  p-[1rem] pl-8 sm:p-[1.875rem] md:p-[1.875rem] sm:text-base mt-2 font-medium text-left text-sm font-fg flex justify-between w-full`}
+                onClick={() => {
+                  if (isDisclosureOpen(id)) {
+                    setOpenDisclosureId(null);
+                  } else {
+                    setOpenDisclosureId(id);
+                  }
+                }}
+              >
+                {question}
 
-                  <motion.span
-                    animate={{ rotate: open ? 180 : 0 }}
-                    transition={{ duration: 0.2 }}
-                  >
-                    <ChevronDown />
-                  </motion.span>
-                </Disclosure.Button>
-                <Disclosure.Panel className="flex flex-col leading-7 justify-around gap-4 px-8 pb-8 pt-6 font-fg text-sm">
+                <motion.span
+                  animate={{ rotate: isDisclosureOpen(id) ? 180 : 0 }}
+                  transition={{ duration: 0.2 }}
+                >
+                  <ChevronDown />
+                </motion.span>
+              </Disclosure.Button>
+              {isDisclosureOpen(id) && (
+                <Disclosure.Panel
+                  static
+                  className="flex flex-col leading-7 justify-around gap-4 px-8 pb-8 pt-6 font-fg text-sm"
+                >
                   {answer}
                 </Disclosure.Panel>
-              </>
-            )}
+              )}
+            </>
           </Disclosure>
         );
       })}

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -1,4 +1,4 @@
-import MobileAccordianMenu from "@/components/mobile-accordian-menu";
+import MobileAccordionMenu from "@/components/mobile-accordion-menu";
 import Link from "next/link";
 import {
   DiscordIcon,
@@ -41,7 +41,7 @@ const MobileFooter = () => {
   return (
     <footer className="px-4 pb-8 mt-10 lg:hidden ">
       <div className="border-t border-primary-dark">
-        <MobileAccordianMenu />
+        <MobileAccordionMenu />
         <div className="flex justify-between">
           <div className="flex flex-col">
             <MentoLogo className="h-5 w-[90px]" />

--- a/src/components/mobile-accordion-menu.tsx
+++ b/src/components/mobile-accordion-menu.tsx
@@ -7,7 +7,7 @@ import Link from "next/link";
 import { links } from "@/lib/constants";
 import { ChevronDown } from "./svgs";
 
-const mobileMenuAccordianMenuItems = [
+const mobileMenuAccordionMenuItems = [
   {
     name: "Developers",
     items: [
@@ -29,10 +29,10 @@ const mobileMenuAccordianMenuItems = [
   },
 ];
 
-const MobileAccordianMenu = () => {
+const MobileAccordionMenu = () => {
   return (
     <div className="flex flex-col mb-8 dark:bg-primary-dark">
-      {mobileMenuAccordianMenuItems
+      {mobileMenuAccordionMenuItems
         .filter(({ items }) => !!items)
         .map(({ name: headingName, items }) => {
           return (
@@ -81,4 +81,4 @@ const MobileAccordianMenu = () => {
   );
 };
 
-export default MobileAccordianMenu;
+export default MobileAccordionMenu;

--- a/src/components/mobile-header.tsx
+++ b/src/components/mobile-header.tsx
@@ -16,7 +16,7 @@ import {
 import { links } from "@/lib/constants";
 import Link from "next/link";
 
-import MobileAccordianMenu from "@/components/mobile-accordian-menu";
+import MobileAccordionMenu from "@/components/mobile-accordion-menu";
 import { DisconnectButton } from "@/components/disconnect-button";
 import { useAccount } from "wagmi";
 import ClientOnly from "./client-only";
@@ -87,7 +87,7 @@ const DropDownMenuOverlay = ({
         ) : (
           <Spacer className="h-[48px]" />
         )}
-        <MobileAccordianMenu />
+        <MobileAccordionMenu />
         <div className="flex flex-col w-full justify-center items-center gap-8">
           <div className="flex flex-col w-full justify-center items-center gap-[18px]">
             <ConnectionButtons isConnected={isConnected} />


### PR DESCRIPTION
## Description

When the user navigates to a FAQ through an anchor tag, the answer should be extended and visible automatically.
Since the component library we use does not directly support extending dropdowns programmatically, I made the answer panel static and controlled it through a new state var: https://github.com/tailwindlabs/headlessui/discussions/589

## Other changes

fixed typo Accordian -> Accordion

## Related Issue

fixes #122 

## Tested

tested on a preview