### PR TITLE
Fix: handle unsupported chains

### DIFF
--- a/src/components/providers.tsx
+++ b/src/components/providers.tsx
@@ -36,7 +36,6 @@ const ConnectionGuard = ({ children }: { children: React.ReactNode }) => {
   useRequireAuth({ enabled: !isLoading });
   useWatchChainOrAccountChange({
     onAccountChange: () => disconnect(),
-    onChainChange: () => disconnect(),
   });
 
   return <>{children}</>;

--- a/src/components/verify-and-claim.tsx
+++ b/src/components/verify-and-claim.tsx
@@ -6,8 +6,10 @@ import Link from "next/link";
 import React from "react";
 import { Locked } from "./svgs";
 import { useCooldown } from "@/hooks/use-cool-down";
-import { disconnect } from "wagmi/actions";
+import { disconnect, switchNetwork } from "wagmi/actions";
 import Loading from "./loading";
+import { useNetwork } from "wagmi";
+import { useChainModal } from "@rainbow-me/rainbowkit";
 
 const ClaimText = () => {
   return (
@@ -56,6 +58,8 @@ export default function VerifyAndClaim({
     merkleProof,
     address,
   });
+  const { chain, chains } = useNetwork();
+  const { openChainModal } = useChainModal();
 
   const claimErrorCooldown = useCooldown(claim.isError, 5000);
   const kycErrorCooldown = useCooldown(kyc.error, 5000);
@@ -85,6 +89,10 @@ export default function VerifyAndClaim({
     }
   };
 
+  const handleChainChange = () => {
+    openChainModal?.();
+  };
+
   const renderOverview = () => {
     if (kyc.isSuccess) {
       return <ClaimAndLockOverview />;
@@ -100,6 +108,12 @@ export default function VerifyAndClaim({
   };
 
   const renderButton = () => {
+    if (chain && !chains.includes(chain)) {
+      <Button onClick={handleChainChange} color="blue">
+        Please change to the correct network
+      </Button>;
+    }
+
     if (claimErrorCooldown.isCoolingDown) {
       return (
         <Button color="blue" disabled>

--- a/src/components/verify-and-claim.tsx
+++ b/src/components/verify-and-claim.tsx
@@ -89,10 +89,6 @@ export default function VerifyAndClaim({
     }
   };
 
-  const handleChainChange = () => {
-    openChainModal?.();
-  };
-
   const renderOverview = () => {
     if (kyc.isSuccess) {
       return <ClaimAndLockOverview />;
@@ -108,12 +104,18 @@ export default function VerifyAndClaim({
   };
 
   const renderButton = () => {
-    if (chain && !chains.includes(chain)) {
-      <Button onClick={handleChainChange} color="blue">
-        Please change to the correct network
-      </Button>;
+    if (chain?.unsupported) {
+      return (
+        <>
+          <Button onClick={() => openChainModal?.()} color="blue">
+            Switch to Celo
+          </Button>
+          <span className="text-red-500">
+            Wrong network detected, please connect to Celo to claim your MENTO
+          </span>
+        </>
+      );
     }
-
     if (claimErrorCooldown.isCoolingDown) {
       return (
         <Button color="blue" disabled>

--- a/src/hooks/use-watch-chain-or-account-change.ts
+++ b/src/hooks/use-watch-chain-or-account-change.ts
@@ -1,3 +1,4 @@
+import { useChainModal } from "@rainbow-me/rainbowkit";
 import React from "react";
 import { ConnectorData, useAccount, useDisconnect } from "wagmi";
 
@@ -10,9 +11,13 @@ const useWatchChainOrAccountChange = ({
 }) => {
   const { connector: activeConnector } = useAccount();
   const { disconnect } = useDisconnect();
+  const { openChainModal } = useChainModal();
 
   React.useEffect(() => {
     const handleConnectorUpdate = ({ account, chain }: ConnectorData) => {
+      if (chain?.unsupported) {
+        openChainModal?.();
+      }
       if (account) {
         onAccountChange && onAccountChange();
       } else if (chain) {
@@ -27,7 +32,7 @@ const useWatchChainOrAccountChange = ({
     return () => {
       activeConnector?.off("change", handleConnectorUpdate);
     };
-  }, [activeConnector, disconnect, onAccountChange, onChainChange]);
+  }, [activeConnector, disconnect, onAccountChange, onChainChange, openChainModal]);
 };
 
 export { useWatchChainOrAccountChange };

--- a/src/lib/wagmi.ts
+++ b/src/lib/wagmi.ts
@@ -12,18 +12,18 @@ import { jsonRpcProvider } from "wagmi/providers/jsonRpc";
 import { Valora, CeloWallet } from "@celo/rainbowkit-celo/wallets";
 
 // Import CELO chain information
-import { Alfajores, Baklava, Celo } from "@celo/rainbowkit-celo/chains";
+import { Alfajores, Celo } from "@celo/rainbowkit-celo/chains";
 
+const isVercelProduction =
+  process.env.NODE_ENV === "production" &&
+  process.env.VERCEL_ENV === "production";
 const projectId = process.env.NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID ?? "";
-
-const { chains, publicClient } = configureChains(
-  [Alfajores, Celo, Baklava],
-  [
-    jsonRpcProvider({
-      rpc: (chain) => ({ http: chain.rpcUrls.default.http[0] }),
-    }),
-  ],
-);
+const chainList = [...(isVercelProduction ? [Celo] : [Celo, Alfajores])];
+const { chains, publicClient } = configureChains(chainList, [
+  jsonRpcProvider({
+    rpc: (chain) => ({ http: chain.rpcUrls.default.http[0] }),
+  }),
+]);
 
 const connectors = connectorsForWallets([
   {


### PR DESCRIPTION
# Description

This PR makes changes to handle cases when users aren't connected to the correct chain. Now we -

- Prompt users to connect to the correct chain the moment they change
- Don't allow users to attempt a claim if they're on the wrong change and prompt them to change chain

## Other Changes

Now, we also add relevant chains based on the `VERCEL_ENV` variable. The Vercel `production` build will only use Celo mainnet. Alafajores will be available in all other cases ( locally and in Vercel dev previews)

## Related tickets

N/A