### PR TITLE
Feat: Global error handling

### DIFF
--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -24,7 +24,7 @@ export default function Error({
       <h3 className="font-fg font-medium text-sm sm:text-base text-center flex flex-col gap-8">
         Unexpected Error
       </h3>
-      <p className="text-center max-w-[500px]">
+      <p className="font-fg text-center text-sm sm:text-base">
         An unexpected error has occurred. We apologize for the inconvenience. To
         ensure your security, we have disconnected your crypto wallet and reset
         the application. Please try to restart the process. If the issue

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,44 @@
+"use client"; // Error components must be Client Components
+import { Button } from "@/components/button";
+import { useSession } from "@/contexts/rainbowkit-siwe-iron-session-provider";
+import * as Sentry from "@sentry/nextjs";
+import Link from "next/link";
+
+import { useEffect } from "react";
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    // Log the error to an error reporting service
+    Sentry.captureException(error);
+  }, [error]);
+  const { logout } = useSession();
+
+  return (
+    <div className="flex flex-col items-center justify-center gap-8 text-center">
+      <h3 className="font-fg font-medium text-sm sm:text-base text-center flex flex-col gap-8">
+        Unexpected Error
+      </h3>
+      <p className="text-center max-w-[500px]">
+        An unexpected error has occurred. We apologize for the inconvenience. To
+        ensure your security, we have disconnected your crypto wallet and reset
+        the application. Please try to restart the process. If the issue
+        persists, <Link href="">contact our support</Link> team for assistance.
+      </p>
+      <Button
+        color="blue"
+        onClick={() => {
+          logout();
+          reset();
+        }}
+      >
+        Try again
+      </Button>
+    </div>
+  );
+}

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -25,10 +25,18 @@ export default function Error({
         Unexpected Error
       </h3>
       <p className="font-fg text-center text-sm sm:text-base">
-        An unexpected error has occurred. We apologize for the inconvenience. To
-        ensure your security, we have disconnected your crypto wallet and reset
-        the application. Please try to restart the process. If the issue
-        persists, <Link href="">contact our support</Link> team for assistance.
+        An unexpected error has occurred. We apologize for the inconvenience.{" "}
+        <br /> Please click the button below to disconnect your wallet & restart
+        the process.
+        <br /> If the issue persists, please open a support ticket in the{" "}
+        <Link
+          className="text-[#4D62F0]"
+          href="https://discord.com/invite/Zszgng9NdF"
+          target="_blank"
+        >
+          Mento discord
+        </Link>{" "}
+        for assistance.
       </p>
       <Button
         color="blue"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -65,7 +65,3 @@ export default function Home() {
     </div>
   );
 }
-
-const ErrorComponent = () => {
-  throw new Error("This is a test error!");
-};

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -14,6 +14,21 @@ export default function Home() {
   const { status } = useSession();
   const { openConnectModal } = useConnectModal();
   const hasMounted = useIsMounted();
+  const [showError, setShowError] = React.useState(false);
+
+  if (showError) {
+    return <ErrorComponent />;
+  }
+
+  return (
+    <button
+      onClick={() => {
+        setShowError(true);
+      }}
+    >
+      Show Error
+    </button>
+  );
 
   if (!hasMounted || status === "loading") {
     return (
@@ -65,3 +80,7 @@ export default function Home() {
     </div>
   );
 }
+
+const ErrorComponent = () => {
+  throw new Error("This is a test error!");
+};

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -14,21 +14,6 @@ export default function Home() {
   const { status } = useSession();
   const { openConnectModal } = useConnectModal();
   const hasMounted = useIsMounted();
-  const [showError, setShowError] = React.useState(false);
-
-  if (showError) {
-    return <ErrorComponent />;
-  }
-
-  return (
-    <button
-      onClick={() => {
-        setShowError(true);
-      }}
-    >
-      Show Error
-    </button>
-  );
 
   if (!hasMounted || status === "loading") {
     return (

--- a/src/hooks/use-refresh-kyc-status.ts
+++ b/src/hooks/use-refresh-kyc-status.ts
@@ -20,16 +20,21 @@ const useRefreshKYCStatus = () => {
       switch (verificationCaseStatus?.status) {
         case "contacted":
           pushIfNotAlreadyOnPage("/?kyc_status=contacted");
+          break;
         case "pending":
           pushIfNotAlreadyOnPage("/kyc-pending");
+          break;
         case "done":
           switch (verificationCaseStatus.credential) {
             case "approved":
               pushIfNotAlreadyOnPage("/allocation");
+              break;
             case "pending":
               pushIfNotAlreadyOnPage("/kyc-pending");
+              break;
             case "rejected":
               pushIfNotAlreadyOnPage("/kyc-rejected");
+              break;
           }
         default:
           pushIfNotAlreadyOnPage("/");


### PR DESCRIPTION
### Description

While we have error handling locally in all of the main functions, This PR adds a global error boundry, which will catch any other unexpected errors which occur.  When this happens the 'error.tsx' page is displayed which will allow the user to reset the app, and log them out of their session. 

note: I've added [a button to trigger](https://github.com/mento-protocol/airgrab-interface/blob/8f981bd66685cbda7f9203cded181229eb90f032/src/app/page.tsx#L19) this error to demonstrate how it will work and look, but it should be removed before merging this.

You can see more details about the `error.tsx` file in the [Next.js docs](https://nextjs.org/docs/app/api-reference/file-conventions/error)

**To Review**
Run the app locally, or visit the preview deployment and press the 'Show Error' button. 

## Other Changes

N/A

## Related tickets

closes #80 