### PR TITLE
feat: add link to gov ui after airdrop completed

### DIFF
--- a/src/components/verify-and-claim.tsx
+++ b/src/components/verify-and-claim.tsx
@@ -270,7 +270,7 @@ const ClaimConfirmation = ({ allocation }: { allocation: string }) => (
       <Button color="blue" onClick={disconnect} fullWidth>
         Check another wallet
       </Button>
-      <Button color="blush" href="https://app.mento.org" fullWidth>
+      <Button color="blush" href="https://governance.mento.org" fullWidth>
         Go to app
       </Button>
     </div>


### PR DESCRIPTION
adds gov url to button at the end of Airdrop process instead of mento app url 