### PR TITLE
Fix: remove celo wallet

### DIFF
--- a/src/lib/wagmi.ts
+++ b/src/lib/wagmi.ts
@@ -9,7 +9,7 @@ import { configureChains, createConfig } from "wagmi";
 import { jsonRpcProvider } from "wagmi/providers/jsonRpc";
 
 // Import known recommended wallets
-import { Valora, CeloWallet } from "@celo/rainbowkit-celo/wallets";
+import { Valora } from "@celo/rainbowkit-celo/wallets";
 
 // Import CELO chain information
 import { Alfajores, Celo } from "@celo/rainbowkit-celo/chains";

--- a/src/lib/wagmi.ts
+++ b/src/lib/wagmi.ts
@@ -30,7 +30,6 @@ const connectors = connectorsForWallets([
     groupName: "Recommended with CELO",
     wallets: [
       Valora({ chains, projectId }),
-      CeloWallet({ chains, projectId }),
       frameWallet({ chains, projectId }),
       metaMaskWallet({ chains, projectId }),
       omniWallet({ chains, projectId }),


### PR DESCRIPTION
This PR removes Celo Wallet from the app. Users are having issues connecting with Celo wallet, and given that it's unmaintained, therefore it's likely that rainbowkit's support for Celo Wallet isn't good. We should removed it. If it's deemed necessary in the future we'll look for a solution to include it