### PR TITLE
feat: update KYC link to disable KYB

### DIFF
--- a/src/components/kyc-button.tsx
+++ b/src/components/kyc-button.tsx
@@ -10,6 +10,7 @@ function buildFractalUrl(wallet?: string): string {
   url.searchParams.append("client_id", FRACTAL_CLIENT_ID);
   url.searchParams.append("redirect_uri", REDIRECT_URL);
   url.searchParams.append("response_type", "code");
+  url.searchParams.append("user_role", "person");
   url.searchParams.append(
     "scope",
     "contact:read verification.plus:read verification.liveness:read verification.wallet-eth:read",


### PR DESCRIPTION
This PR makes a change to the KYC link to require the `user_role` to be `person,` disabling the option for a user to verify using the KYB (Know Your Business) option. This is based on instructions received from Fractal ID in our shared telegram channel.