### PR TITLE
fix: use "NEXT_PUBLIC" to get vercel system variable client side

### DIFF
--- a/src/lib/wagmi.ts
+++ b/src/lib/wagmi.ts
@@ -14,11 +14,9 @@ import { Valora } from "@celo/rainbowkit-celo/wallets";
 // Import CELO chain information
 import { Alfajores, Celo } from "@celo/rainbowkit-celo/chains";
 
-const isVercelProduction =
-  process.env.NODE_ENV === "production" &&
-  process.env.VERCEL_ENV === "production";
+const isVercelProduction = process.env.NEXT_PUBLIC_VERCEL_ENV === "production";
 const projectId = process.env.NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID ?? "";
-const chainList = [...(isVercelProduction ? [Celo] : [Alfajores, Celo])];
+const chainList = [...(isVercelProduction ? [Celo] : [Celo, Alfajores])];
 const { chains, publicClient } = configureChains(chainList, [
   jsonRpcProvider({
     rpc: (chain) => ({ http: chain.rpcUrls.default.http[0] }),


### PR DESCRIPTION
This PR makes a small change to get Vercel system env variables Client Side but using the NEXT_PUBLIC prefix