### PR TITLE
Fix: Make sure allocation check is boolean

### DIFF
--- a/src/app/allocation/page.tsx
+++ b/src/app/allocation/page.tsx
@@ -17,7 +17,7 @@ export default async function Allocation() {
   const fullAddress = getAddressForSession(session);
   const shortAddress = fullAddress ? shortenAddress(fullAddress) : "";
   const allocation = await getAllocationForAddress(fullAddress);
-  const hasAllocation = allocation && allocation !== "0";
+  const hasAllocation = Boolean(allocation && allocation !== "0");
 
   const isBeforeLaunch = new Date(LAUNCH_DATE).getTime() > Date.now();
 


### PR DESCRIPTION
This PR handles an edge case where an `eligible` screen would show even when the allocation for an address doesn't exist. I Now we convert the allocation to a big int + convert the check to a boolean in the allocation check