### PR TITLE
Fix: Enable KYB Claiming

### DIFF
--- a/src/components/kyc-button.tsx
+++ b/src/components/kyc-button.tsx
@@ -10,7 +10,6 @@ function buildFractalUrl(wallet?: string): string {
   url.searchParams.append("client_id", FRACTAL_CLIENT_ID);
   url.searchParams.append("redirect_uri", REDIRECT_URL);
   url.searchParams.append("response_type", "code");
-  url.searchParams.append("user_role", "person");
   url.searchParams.append(
     "scope",
     "contact:read verification.plus:read verification.liveness:read verification.wallet-eth:read",

--- a/src/hooks/use-claim-mento.tsx
+++ b/src/hooks/use-claim-mento.tsx
@@ -48,7 +48,7 @@ export const useClaimMento = ({
     approvedAt,
     fractalId,
   });
-  const gasEstimate = useEstimateGas(
+  const { data: gasEstimate, error } = useEstimateGas(
     preparedClaimArgs
       ? {
           address: addresses.Airgrab as Address,
@@ -59,6 +59,8 @@ export const useClaimMento = ({
         }
       : null,
   );
+
+  console.log({ error });
 
   const claimStatus = useContractRead({
     address: addresses.Airgrab as Address,

--- a/src/hooks/use-claim-mento.tsx
+++ b/src/hooks/use-claim-mento.tsx
@@ -48,7 +48,7 @@ export const useClaimMento = ({
     approvedAt,
     fractalId,
   });
-  const { data: gasEstimate, error } = useEstimateGas(
+  const { data: gasEstimate, error: isGasEstimateError } = useEstimateGas(
     preparedClaimArgs
       ? {
           address: addresses.Airgrab as Address,
@@ -59,8 +59,6 @@ export const useClaimMento = ({
         }
       : null,
   );
-
-  console.log({ error });
 
   const claimStatus = useContractRead({
     address: addresses.Airgrab as Address,
@@ -151,7 +149,9 @@ export const useClaimMento = ({
     prepare: {
       ...prepare,
       isError:
-        prepare.isError && !(prepare.error instanceof UserRejectedRequestError),
+        (prepare.isError &&
+          !(prepare.error instanceof UserRejectedRequestError)) ||
+        isGasEstimateError,
     },
     confirmation: wait,
     claim: {

--- a/src/hooks/use-kyc-proof.ts
+++ b/src/hooks/use-kyc-proof.ts
@@ -6,6 +6,7 @@ import { toast } from "sonner";
 
 import { fetchJson } from "@/lib/utils";
 import { createFractalAuthMessage } from "@/lib/authMessage";
+import useVerificationType from "./use-verification-type";
 
 export type FractalVerificationDetails = {
   proof: `0x${string}` | undefined;
@@ -33,8 +34,11 @@ const fetchProof = async (
 };
 
 export const useKYCProof = () => {
+  const { data: verificationType, isLoading: isVerificationTypeLoading } =
+    useVerificationType();
+    
   const signature = useSignMessage({
-    message: createFractalAuthMessage(),
+    message: createFractalAuthMessage(verificationType),
     onSettled: (data: `0x${string}` | undefined, e: Error | null) => {
       if (e instanceof Error && !(e instanceof UserRejectedRequestError)) {
         toast.error(e.message);
@@ -68,6 +72,7 @@ export const useKYCProof = () => {
       error: signature.error || kyc.error,
       isError: signature.isError || kyc.error,
       signMessage: signature.signMessage,
+      isReady: verificationType && !isVerificationTypeLoading,
     },
   };
 };

--- a/src/hooks/use-kyc-proof.ts
+++ b/src/hooks/use-kyc-proof.ts
@@ -34,9 +34,12 @@ const fetchProof = async (
 };
 
 export const useKYCProof = () => {
-  const { data: verificationType, isLoading: isVerificationTypeLoading } =
-    useVerificationType();
-    
+  const {
+    data: verificationType,
+    isLoading: isVerificationTypeLoading,
+    error: verificationTypeError,
+  } = useVerificationType();
+
   const signature = useSignMessage({
     message: createFractalAuthMessage(verificationType),
     onSettled: (data: `0x${string}` | undefined, e: Error | null) => {
@@ -69,8 +72,8 @@ export const useKYCProof = () => {
       isLoadingProof: kyc.isLoading,
       isSuccess: !kyc.error && signature.isSuccess,
       data: kyc.data,
-      error: signature.error || kyc.error,
-      isError: signature.isError || kyc.error,
+      error: signature.error || kyc.error || verificationTypeError,
+      isError: signature.isError || kyc.error || verificationTypeError,
       signMessage: signature.signMessage,
       isReady: verificationType && !isVerificationTypeLoading,
     },

--- a/src/hooks/use-verification-type.ts
+++ b/src/hooks/use-verification-type.ts
@@ -1,0 +1,16 @@
+import { VerificationCase } from "@/lib/fractal";
+import useSWR from "swr";
+
+const useVerificationType = () => {
+  return useSWR(
+    "refresh-kyc",
+    async () => {
+      const res = await fetch("/api/kyc/refresh");
+      const verificationCase: VerificationCase = await res.json();
+      return verificationCase?.type;
+    },
+    { revalidateOnFocus: false },
+  );
+};
+
+export default useVerificationType;

--- a/src/lib/authMessage.ts
+++ b/src/lib/authMessage.ts
@@ -19,10 +19,12 @@ function countryList(countryCodes: string[]): string {
     .join(", ");
 }
 
-export function createFractalAuthMessage(): string {
+export function createFractalAuthMessage(
+  verificationType: string = "KYC",
+): string {
   const countriesString = countryList(RESTRICTED_COUNTRIES.split(","));
 
   return `I authorize Airdrop (${FRACTAL_CLIENT_ID}) to get a proof from Fractal that:
-- I passed KYC level plus+liveness
+- I passed ${verificationType} level plus+liveness
 - I am not a resident of the following countries: ${countriesString}`;
 }

--- a/src/lib/fractal.ts
+++ b/src/lib/fractal.ts
@@ -112,8 +112,6 @@ export async function refetchKycStatus(
       address,
     );
 
-    console.log({ kycStatus });
-
     return kycStatus;
   } catch (error) {
     // TODO: sentrify


### PR DESCRIPTION
## Description 

This PR makes a few changes to the claim flow to allow users who want to use KYB verification to claim. There are two main changes. 

1.  We've removed the requirement for the user to be a person enabling them to KYB. 
2.  We check users' `verification case` for the presence of a property called `person,` which only exists with a `null` value when the verification is for an entity. This info is used to determine if we need to use the `KYB` or `KYC` in the Fractal ID message, which is then used to get a Fractal ID proof

### Other Changes

 Cleaned up the gas estimation hook to use SWR for better error handling.

### Tested

It's a bit harder to test this E2E atm, but we're confident that it works based on a few things: 
We used an account with KYB verification to - 

1. Sign a message and use it to receive a Fractal ID proof ( proves new message change works ) 
3. When trying to claim, we receive a ['Not in tree' error ](https://github.com/mento-protocol/mento-core/blob/7323a6135c3d46aa5964bcf160b1fc14f29145c9/contracts/governance/Airgrab.sol#L124)( proves see successfully passed the [hasValidKyc check](https://github.com/mento-protocol/mento-core/blob/7323a6135c3d46aa5964bcf160b1fc14f29145c9/contracts/governance/Airgrab.sol#L198) which happens first. 

### Related Issues

fixes #182 

